### PR TITLE
Allow capture of captured values

### DIFF
--- a/src/expression.rs
+++ b/src/expression.rs
@@ -30,11 +30,16 @@ impl<TS: TypeSystem> Debug for NativeFunction<TS> {
     }
 }
 
+#[derive(Clone, Debug, PartialEq)]
+pub enum VariableType {
+    Captured(usize),
+    Stack(usize),
+}
+
 #[derive(Debug)]
 pub enum Expression<TS: TypeSystem> {
     RawValue(TS::Value),
-    Variable(usize),
-    CapturedValue(usize),
+    Variable(VariableType),
     Global(usize),
     BinaryOpEval(TS::BinaryOp, Box<[Expression<TS>; 2]>),
     UnaryOpEval(TS::UnaryOp, Box<Expression<TS>>),
@@ -44,4 +49,14 @@ pub enum Expression<TS: TypeSystem> {
     FunctionCapture(FunctionRef<TS>),
     AssignStack(usize, Box<Expression<TS>>),
     AssignGlobal(usize, Box<Expression<TS>>),
+}
+
+impl<TS: TypeSystem> Expression<TS> {
+    pub fn stack(addr: usize) -> Expression<TS> {
+        Expression::Variable(VariableType::Stack(addr))
+    }
+
+    pub fn captured(addr: usize) -> Expression<TS> {
+        Expression::Variable(VariableType::Captured(addr))
+    }
 }

--- a/src/function.rs
+++ b/src/function.rs
@@ -1,3 +1,4 @@
+use crate::expression::VariableType;
 use crate::{execution_engine::Function, expression::Expression, TypeSystem};
 
 use std::fmt::Debug;
@@ -16,7 +17,7 @@ pub enum FunctionType<TS: TypeSystem> {
     /// Static reference to a function, which can't capture any values.
     Static,
     /// Reference to a function which captures values, but hasn't been initialized with those values.
-    CapturingDef(Vec<usize>),
+    CapturingDef(Vec<VariableType>),
     /// A reference to a function which captures values bundled with those captured values
     CapturingRef(Rc<[TS::Value]>),
 }
@@ -42,7 +43,7 @@ impl<TS: TypeSystem> FunctionWriter<TS> {
     /// Create a capturing function (closure)
     /// args: How many arguments the function will take
     /// capture: What items in the current stack frame to capture when creating an instance
-    pub fn new_capturing(args: usize, capture: Vec<usize>) -> FunctionWriter<TS> {
+    pub fn new_capturing(args: usize, capture: Vec<VariableType>) -> FunctionWriter<TS> {
         Self {
             args,
             stack_size: args,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,3 @@
-use error::FreightError;
-use execution_engine::ExecutionEngine;
 use operators::{binary::BinaryOperator, unary::UnaryOperator};
 use std::fmt::Debug;
 use value::Value;

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -12,7 +12,7 @@ fn test_functions() {
     let b = add.argument_stack_offset(1);
     add.return_expression(Expression::BinaryOpEval(
         TestBinaryOperator::Add,
-        [Expression::Variable(a), Expression::Variable(b)].into(),
+        [Expression::stack(a), Expression::stack(b)].into(),
     ));
     let add = writer.include_function(add);
     let mut main = FunctionWriter::new(0);
@@ -28,7 +28,7 @@ fn test_functions() {
     );
     main.return_expression(Expression::StaticFunctionCall(
         add,
-        vec![Expression::Variable(x), Expression::Variable(y)],
+        vec![Expression::stack(x), Expression::stack(y)],
     ));
     let main = writer.include_function(main);
     let mut vm = writer.finish(main);

--- a/src/vm_writer.rs
+++ b/src/vm_writer.rs
@@ -1,5 +1,4 @@
 use crate::{
-    error::FreightError,
     execution_engine::{ExecutionEngine, Function},
     expression::{Expression, NativeFunction},
     function::{FunctionRef, FunctionWriter},
@@ -50,11 +49,10 @@ impl<TS: TypeSystem> VMWriter<TS> {
         f: NativeFunction<TS>,
     ) -> FunctionRef<TS> {
         let mut func = FunctionWriter::new(N);
-        let args = (0..N).map(|n| Expression::Variable(n)).collect();
-        func.evaluate_expression(Expression::NativeFunctionCall(
-            f,
-            args,
-        ));
+        let args = (0..N)
+            .map(|n| Expression::stack(n))
+            .collect();
+        func.evaluate_expression(Expression::NativeFunctionCall(f, args));
         self.include_function(func)
     }
 


### PR DESCRIPTION
Previously, since captured and stack values are passed separately, you couldn't capture values that were captured in the parent scope