### PR TITLE
Create initializers

### DIFF
--- a/src/execution_engine.rs
+++ b/src/execution_engine.rs
@@ -4,7 +4,7 @@ use crate::{
     error::FreightError,
     expression::{Expression, VariableType},
     function::{FunctionRef, FunctionType},
-    operators::{binary::BinaryOperator, unary::UnaryOperator},
+    operators::{BinaryOperator, UnaryOperator, Initializer},
     value::Value,
     TypeSystem,
 };
@@ -154,6 +154,13 @@ fn evaluate<TS: TypeSystem>(
             target.assign(value);
             Default::default()
         }
+        Expression::Initialize(init, args) => {
+            let mut collected = Vec::with_capacity(args.len());
+            for arg in args {
+                collected.push(evaluate(arg, engine, stack, captured)?);
+            }
+            init.initialize(collected)
+        },
     };
     Ok(result)
 }

--- a/src/expression.rs
+++ b/src/expression.rs
@@ -43,6 +43,7 @@ pub enum Expression<TS: TypeSystem> {
     Variable(VariableType),
     BinaryOpEval(TS::BinaryOp, Box<[Expression<TS>; 2]>),
     UnaryOpEval(TS::UnaryOp, Box<Expression<TS>>),
+    Initialize(TS::Init, Vec<Expression<TS>>),
     StaticFunctionCall(FunctionRef<TS>, Vec<Expression<TS>>),
     DynamicFunctionCall(Box<Expression<TS>>, Vec<Expression<TS>>),
     NativeFunctionCall(NativeFunction<TS>, Vec<Expression<TS>>),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-use operators::{binary::BinaryOperator, unary::UnaryOperator};
+use operators::{BinaryOperator, UnaryOperator, Initializer};
 use std::fmt::Debug;
 use value::Value;
 
@@ -14,6 +14,7 @@ pub trait TypeSystem: Debug + Clone + 'static {
     type Value: Value<TS = Self>;
     type UnaryOp: UnaryOperator<Self::Value>;
     type BinaryOp: BinaryOperator<Self::Value>;
+    type Init: Initializer<Self::Value>;
     type TypeId: PartialEq + Debug;
 }
 

--- a/src/operators.rs
+++ b/src/operators.rs
@@ -1,0 +1,26 @@
+use crate::value::Value;
+use std::fmt::Debug;
+
+#[derive(Clone, Debug)]
+pub enum Operator<TS: crate::TypeSystem> {
+    Binary(TS::BinaryOp),
+    Unary(TS::UnaryOp),
+}
+
+pub trait UnaryOperator<V: Value>: Debug + Clone {
+    fn apply_1(&self, val: &V) -> V;
+}
+
+pub trait BinaryOperator<V: Value>: Debug + Clone {
+    fn apply_2(&self, a: &V, b: &V) -> V;
+}
+
+pub trait Initializer<V: Value>: Debug + Clone {
+    fn initialize(&self, values: Vec<V>) -> V;
+}
+
+impl<V: Value> Initializer<V> for () {
+    fn initialize(&self, _: Vec<V>) -> V {
+        V::default()
+    }
+}

--- a/src/operators/binary.rs
+++ b/src/operators/binary.rs
@@ -1,7 +1,0 @@
-use std::fmt::Debug;
-
-use crate::value::Value;
-
-pub trait BinaryOperator<V: Value>: Debug + Clone {
-    fn apply_2(&self, a: &V, b: &V) -> V;
-}

--- a/src/operators/mod.rs
+++ b/src/operators/mod.rs
@@ -1,8 +1,0 @@
-pub mod binary;
-pub mod unary;
-
-#[derive(Clone, Debug)]
-pub enum Operator<TS: crate::TypeSystem> {
-    Binary(TS::BinaryOp),
-    Unary(TS::UnaryOp),
-}

--- a/src/operators/unary.rs
+++ b/src/operators/unary.rs
@@ -1,7 +1,0 @@
-use std::fmt::Debug;
-
-use crate::value::Value;
-
-pub trait UnaryOperator<V: Value>: Debug + Clone {
-    fn apply_1(&self, val: &V) -> V;
-}

--- a/src/tests/type_system.rs
+++ b/src/tests/type_system.rs
@@ -2,7 +2,7 @@
 
 use crate::{
     function::FunctionRef,
-    operators::{binary::BinaryOperator, unary::UnaryOperator},
+    operators::{BinaryOperator, UnaryOperator, Initializer},
     value::Value,
     TypeSystem,
 };
@@ -18,6 +18,8 @@ impl TypeSystem for TestTypeSystem {
     type BinaryOp = TestBinaryOperator;
 
     type TypeId = TestTypeId;
+
+    type Init = ();
 }
 
 #[derive(Debug, Clone)]

--- a/src/vm_writer.rs
+++ b/src/vm_writer.rs
@@ -44,12 +44,13 @@ impl<TS: TypeSystem> VMWriter<TS> {
         }
     }
 
-    pub fn include_native_function<const N: usize>(
+    pub fn include_native_function(
         &mut self,
         f: NativeFunction<TS>,
+        args: usize,
     ) -> FunctionRef<TS> {
-        let mut func = FunctionWriter::new(N);
-        let args = (0..N)
+        let mut func = FunctionWriter::new(args);
+        let args = (0..args)
             .map(|n| Expression::stack(n))
             .collect();
         func.evaluate_expression(Expression::NativeFunctionCall(f, args));


### PR DESCRIPTION
Initializers will be used for things like lists and maps that have a variable number of sub-expressions, evaluated at runtime, which will be used to create a single value. I have implemented `Initializer` on `()` so that people can use `()` as their initializer type if their language has no initializers. `()` as an initializer will always return the default Value.

I also moved all the operator traits (including initializers) into a single file. This will require changing the imports in Fender once it's merged.