### PR TITLE
Add global context

### DIFF
--- a/src/execution_engine.rs
+++ b/src/execution_engine.rs
@@ -26,6 +26,7 @@ pub struct ExecutionEngine<TS: TypeSystem> {
     pub(crate) entry_point: usize,
     pub(crate) stack_size: usize,
     pub(crate) return_value: TS::Value,
+    pub context: TS::GlobalContext,
 }
 
 impl<TS: TypeSystem> ExecutionEngine<TS> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,6 +22,8 @@ pub trait TypeSystem: Debug + Clone + 'static {
     type Init: Initializer<Self::Value>;
     /// The type id type for a language
     type TypeId: PartialEq + Debug;
+    /// A global context object to be stored in the ExecutionEngine
+    type GlobalContext;
 }
 
 #[cfg(test)]

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -31,6 +31,6 @@ fn test_functions() {
         vec![Expression::stack(x), Expression::stack(y)],
     ));
     let main = writer.include_function(main, 0);
-    let mut vm = writer.finish(main);
+    let mut vm = writer.finish_default(main);
     assert_eq!(vm.run().unwrap(), TestValueWrapper(TestValue::Number(5)));
 }

--- a/src/tests/type_system.rs
+++ b/src/tests/type_system.rs
@@ -20,6 +20,8 @@ impl TypeSystem for TestTypeSystem {
     type TypeId = TestTypeId;
 
     type Init = ();
+
+    type GlobalContext = ();
 }
 
 #[derive(Debug, Clone)]
@@ -82,6 +84,10 @@ impl Value for TestValueWrapper {
 
     fn assign(&mut self, value: <Self::TS as TypeSystem>::Value) {
         self.0 = value.0;
+    }
+
+    fn into_ref(self) -> Self {
+        self
     }
 }
 

--- a/src/vm_writer.rs
+++ b/src/vm_writer.rs
@@ -70,7 +70,11 @@ impl<TS: TypeSystem> VMWriter<TS> {
     }
 
     /// Build an [ExecutionEngine] with the given function as an entry point
-    pub fn finish(self, entry_point: FunctionRef<TS>) -> ExecutionEngine<TS> {
+    pub fn finish(
+        self,
+        entry_point: FunctionRef<TS>,
+        context: TS::GlobalContext,
+    ) -> ExecutionEngine<TS> {
         ExecutionEngine {
             num_globals: self.globals,
             globals: vec![],
@@ -78,6 +82,22 @@ impl<TS: TypeSystem> VMWriter<TS> {
             entry_point: entry_point.location,
             stack_size: entry_point.stack_size,
             return_value: Default::default(),
+            context,
+        }
+    }
+
+    pub fn finish_default(self, entry_point: FunctionRef<TS>) -> ExecutionEngine<TS>
+    where
+        TS::GlobalContext: Default,
+    {
+        ExecutionEngine {
+            num_globals: self.globals,
+            globals: vec![],
+            functions: self.functions.into(),
+            entry_point: entry_point.location,
+            stack_size: entry_point.stack_size,
+            return_value: Default::default(),
+            context: Default::default(),
         }
     }
 }


### PR DESCRIPTION
This will allow us to attach arbitrary global data to the execution engine, which should enable the standard library loader to load dependencies and allow us to create a global struct metadata table